### PR TITLE
fix: resolve TypeScript build error in API route type cast

### DIFF
--- a/src/app/api/tailor/route.ts
+++ b/src/app/api/tailor/route.ts
@@ -51,8 +51,10 @@ function validateRequest(
   );
 }
 
-function validateApiKeyField(body: Record<string, unknown>): boolean {
-  if ("apiKey" in body && body.apiKey !== undefined && typeof body.apiKey !== "string") {
+function validateApiKeyField(body: unknown): boolean {
+  if (!body || typeof body !== "object") return true;
+  const b = body as Record<string, unknown>;
+  if ("apiKey" in b && b.apiKey !== undefined && typeof b.apiKey !== "string") {
     return false;
   }
   return true;
@@ -76,7 +78,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  if (!validateApiKeyField(body as unknown as Record<string, unknown>)) {
+  if (!validateApiKeyField(body)) {
     return NextResponse.json(
       { error: "Invalid apiKey: must be a string" },
       { status: 400 }


### PR DESCRIPTION
Fixes Vercel build failure - TailorRequest to Record<string, unknown> cast needs intermediate unknown cast for TypeScript strict mode compatibility.