### PR TITLE
fix: hide Get Started button on tailor pages

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import React from "react";
 
 // Mock next/link to render a plain anchor
@@ -21,6 +21,11 @@ jest.mock("next/link", () => ({
 
 // Mock globals.css
 jest.mock("../globals.css", () => ({}));
+
+// Mock the Navbar component since it's a client component with usePathname
+jest.mock("@/components/Navbar", () => ({
+  Navbar: () => <nav data-testid="navbar">Navbar</nav>,
+}));
 
 describe("Layout", () => {
   it("exports metadata with correct title and description", async () => {
@@ -61,30 +66,9 @@ describe("Layout", () => {
         { container: document.createElement("div") }
       );
 
-      // Check nav exists
-      const nav = container.querySelector("nav");
+      // Check nav exists (mocked Navbar)
+      const nav = container.querySelector('[data-testid="navbar"]');
       expect(nav).toBeTruthy();
-
-      // Check brand link
-      const links = container.querySelectorAll("a");
-      const brandLink = Array.from(links).find((a) =>
-        a.textContent?.includes("AI Resume Tailor")
-      );
-      expect(brandLink).toBeTruthy();
-      expect(brandLink?.getAttribute("href")).toBe("/");
-
-      // Check "Get Started" link in navbar
-      const getStartedLink = Array.from(links).find((a) =>
-        a.textContent?.includes("Get Started")
-      );
-      expect(getStartedLink).toBeTruthy();
-      expect(getStartedLink?.getAttribute("href")).toBe("/tailor");
-
-      // Check Settings link in navbar
-      const settingsLink = Array.from(links).find(
-        (a) => a.getAttribute("href") === "/settings"
-      );
-      expect(settingsLink).toBeTruthy();
 
       // Check footer
       const footer = container.querySelector("footer");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import Link from "next/link";
 import "./globals.css";
+import { Navbar } from "@/components/Navbar";
 
 // TODO: Add a custom favicon — currently using default Next.js favicon.ico
 export const metadata: Metadata = {
@@ -15,56 +15,6 @@ export const metadata: Metadata = {
     type: "website",
   },
 };
-
-function Navbar() {
-  return (
-    <nav className="border-b border-border">
-      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4 sm:px-6">
-        <Link
-          href="/"
-          className="text-base font-semibold tracking-tight sm:text-lg"
-        >
-          AI Resume Tailor
-        </Link>
-        <div className="flex items-center gap-3 sm:gap-4">
-          <Link
-            href="/settings"
-            className="flex items-center gap-1.5 text-sm font-medium text-muted transition-colors hover:text-foreground"
-            aria-label="Settings"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-            </svg>
-            <span className="hidden sm:inline">Settings</span>
-          </Link>
-          <Link
-            href="/tailor"
-            className="rounded-lg bg-accent px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover sm:px-4 sm:py-2"
-          >
-            Get Started
-          </Link>
-        </div>
-      </div>
-    </nav>
-  );
-}
 
 function Footer() {
   return (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export function Navbar() {
+  const pathname = usePathname();
+  const isTailorPage = pathname.startsWith("/tailor");
+
+  return (
+    <nav className="border-b border-border">
+      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4 sm:px-6">
+        <Link
+          href="/"
+          className="text-base font-semibold tracking-tight sm:text-lg"
+        >
+          AI Resume Tailor
+        </Link>
+        <div className="flex items-center gap-3 sm:gap-4">
+          <Link
+            href="/settings"
+            className="flex items-center gap-1.5 text-sm font-medium text-muted transition-colors hover:text-foreground"
+            aria-label="Settings"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+            <span className="hidden sm:inline">Settings</span>
+          </Link>
+          {!isTailorPage && (
+            <Link
+              href="/tailor"
+              className="rounded-lg bg-accent px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover sm:px-4 sm:py-2"
+            >
+              Get Started
+            </Link>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Mock next/link
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock next/navigation
+const mockUsePathname = jest.fn();
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+import { Navbar } from "../Navbar";
+
+describe("Navbar", () => {
+  beforeEach(() => {
+    mockUsePathname.mockReset();
+  });
+
+  it("renders brand link to home", () => {
+    mockUsePathname.mockReturnValue("/");
+    render(<Navbar />);
+    const brandLink = screen.getByText("AI Resume Tailor");
+    expect(brandLink.closest("a")).toHaveAttribute("href", "/");
+  });
+
+  it("renders settings link", () => {
+    mockUsePathname.mockReturnValue("/");
+    render(<Navbar />);
+    const settingsLink = screen.getByLabelText("Settings");
+    expect(settingsLink).toHaveAttribute("href", "/settings");
+  });
+
+  it("shows Get Started button on home page", () => {
+    mockUsePathname.mockReturnValue("/");
+    render(<Navbar />);
+    const getStarted = screen.getByText("Get Started");
+    expect(getStarted.closest("a")).toHaveAttribute("href", "/tailor");
+  });
+
+  it("shows Get Started button on settings page", () => {
+    mockUsePathname.mockReturnValue("/settings");
+    render(<Navbar />);
+    const getStarted = screen.getByText("Get Started");
+    expect(getStarted.closest("a")).toHaveAttribute("href", "/tailor");
+  });
+
+  it("hides Get Started button on /tailor page", () => {
+    mockUsePathname.mockReturnValue("/tailor");
+    render(<Navbar />);
+    expect(screen.queryByText("Get Started")).toBeNull();
+  });
+
+  it("hides Get Started button on /tailor/result page", () => {
+    mockUsePathname.mockReturnValue("/tailor/result");
+    render(<Navbar />);
+    expect(screen.queryByText("Get Started")).toBeNull();
+  });
+});


### PR DESCRIPTION
Yan's feedback: the Get Started button shouldn't show when you're already on the tailor page.

Changes:
- Extracted Navbar into a client component (`src/components/Navbar.tsx`) using `usePathname` to detect current route
- Hides Get Started button on `/tailor` and `/tailor/result`
- 6 new Navbar tests, all 108 tests passing