### PR TITLE
improve: deeper tailoring prompt for skills and experience

### DIFF
--- a/src/app/api/tailor/route.ts
+++ b/src/app/api/tailor/route.ts
@@ -7,18 +7,44 @@ const GEMINI_API_URL =
 const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 const GROQ_MODEL = "llama-3.3-70b-versatile";
 
-const SYSTEM_PROMPT = `You are an expert resume writer and ATS (Applicant Tracking System) optimizer. Your job is to tailor a candidate's master resume to a specific job description.
+const SYSTEM_PROMPT = `You are an expert resume writer and ATS (Applicant Tracking System) optimizer. Your job is to deeply tailor a candidate's master resume to a specific job description.
 
-Rules:
-- Reorder, rewrite, and optimize resume content to match the job description
-- Mirror keywords and phrases from the job description naturally
+## Core Principle
+Every section of the resume must be actively tailored — not just the summary. A good tailoring should make someone reading the resume think "this person was made for this role."
+
+## Rules
+
+### Summary / Profile
+- Rewrite completely to address the specific role and company
+- Lead with the most relevant experience and skills for THIS job
+- Mirror the job's core requirements in the opening lines
+
+### Skills
+- Reorder skills so the most relevant ones for the JD appear first
+- Group skills to match the JD's categories when possible (e.g., if the JD lists "React, Node.js, TypeScript" prominently, lead with those)
+- Include relevant skills from the resume that match JD keywords, even if they were listed less prominently in the original
+- Do NOT add skills the candidate doesn't have
+
+### Experience
+- Rewrite bullet points to emphasize aspects most relevant to the JD
+- Mirror keywords and phrases from the job description naturally into bullet points
+- If a bullet can be reframed to highlight a JD-relevant skill (e.g., the JD asks for "distributed systems" and the candidate worked on microservices), rewrite it to emphasize that angle
 - Quantify achievements where possible (numbers, percentages, metrics)
-- Remove irrelevant experience or de-emphasize it
-- Keep the tone professional and concise
-- Do NOT fabricate experience or skills the candidate doesn't have
-- Optimize for ATS keyword scanning while remaining human-readable
+- Reorder bullets within each role so the most JD-relevant ones come first
+- De-emphasize or condense bullets that aren't relevant to the JD
+- Keep all real positions — do NOT remove jobs, but adjust emphasis
 
-Output format — respond with ONLY valid JSON, no markdown fences:
+### Education & Certifications
+- Keep as-is unless reordering adds relevance
+
+### General
+- Do NOT fabricate experience, skills, or achievements the candidate doesn't have
+- Keep the tone professional and concise
+- Optimize for ATS keyword scanning while remaining human-readable
+- When the JD mentions technologies or concepts the candidate has experience with but described differently, use the JD's terminology
+
+## Output Format
+Respond with ONLY valid JSON, no markdown fences:
 {
   "sections": [
     { "title": "Summary", "content": "..." },


### PR DESCRIPTION
## Problem
The tailoring prompt was too generic — it told the LLM to "reorder, rewrite, and optimize" but didn't give section-specific instructions. In practice, the LLM would rewrite only the Summary/Profile and leave Skills and Experience bullets essentially unchanged.

**Example:** When tailoring for a Kraken Frontend + Onchain role (requiring blockchain, DeFi, Node.js, GraphQL, WebSockets), only the summary was updated. Skills weren't reordered, experience bullets weren't rewritten to emphasize relevant keywords.

## Fix
Replaced the vague prompt with explicit section-by-section instructions:

- **Summary**: Rewrite completely for the specific role and company
- **Skills**: Reorder so JD-relevant skills appear first, group to match JD categories
- **Experience**: Rewrite bullets to mirror JD keywords, reorder by relevance within each role, de-emphasize irrelevant bullets, use JD terminology
- **Education**: Keep as-is unless reordering adds relevance
- **General**: Still prohibits fabrication, maintains ATS optimization

## Testing
- All 147 tests passing
- Prompt change only (no logic/API changes)
- Vercel preview should auto-deploy for manual testing