### PR TITLE
chore: add min-release-age=7 for supply chain protection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Security: delay new package versions by 7 days to avoid supply chain attacks
+# (e.g., Bitwarden CLI compromise Apr 2026, event-stream, ua-parser-js)
+# Requires npm 11.10+
+min-release-age=7


### PR DESCRIPTION
Adds a 7-day delay on new npm package versions before they're installable, mitigating supply chain attacks like the Bitwarden CLI compromise (Apr 2026).

Requires npm 11.10+. No impact on existing dependencies — only affects future `npm install` of brand-new versions.

Context: https://socket.dev/blog/bitwarden-cli-compromised